### PR TITLE
MAVEN-1 Relocate the jacoco lenient limit artifact from ddf-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@ Repository of re-usable Maven utilities.
 
 ### Modules
 The following modules are defined:
-* module-1
+* jacoco
  
-#### module-1
-Defines something
+#### jacoco
+Provides extensions for the Jacoco maven plugin. 
+
+[`LenientLimit`](jacoco/src/main/java/org/codice/jacoco/LenientLimit.java) provides an extension to Jacoco's standard limit implementation which is more lenient with respect to the minimum and maximum limits to which a value is compared against. 
+This should help account for small differences in Java compiler and OS as these can be generating different bytecodes.
+
+System properties supported:
+* `offsetJacoco` - specifies the offset to apply to the minimum and maximum values read from pom files in order to be lenient about the comparison. Defaults to 0.02.
+* `computeJacoco` - forces the limit minimum and maximum values as such that Jacoco's comparison will fail and yield warnings that includes the new computed values. This can be useful when one wants to update the pom files after having made changes to the source code or to the test cases.
 
 ### Future iterations
 Future implementations will:
-* do something else
+* Provide CI/CD support

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codice.maven</groupId>
+        <artifactId>codice-maven</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <name>Codice Maven :: Jacoco</name>
+    <artifactId>jacoco</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${maven-jacoco-plugin.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jacoco/src/main/java/org/codice/jacoco/LenientLimit.java
+++ b/jacoco/src/main/java/org/codice/jacoco/LenientLimit.java
@@ -18,29 +18,37 @@ import org.jacoco.report.check.Limit;
 
 /**
  * Extension to Jacoco's {@link Limit} class which is more lenient with respect to the minimum and
- * maximum limits to which a value is compared against. This should help account for small differences
- * in Java compiler and OS as these can be generating different bytecodes.
+ * maximum limits to which a value is compared against. This should help account for small
+ * differences in Java compiler and OS as these can be generating different bytecodes.
  *
  * <p>System properties supported:
+ *
  * <ul>
- *   <li>offsetJacoco - specifies the offset to apply to the minimum and maximum values read from pom
- *   files in order to be lenient about the comparison. Defaults to 0.02.</li>
+ *   <li>offsetJacoco - specifies the offset to apply to the minimum and maximum values read from
+ *       pom files in order to be lenient about the comparison. Defaults to 0.02.
  *   <li>computeJacoco - forces the limit minimum and maximum values as such that Jacoco's
- *   comparison will fail and yield warnings that includes the new computed values. This can be
- *   useful when one wants to update the pom files after having made changes to the source code or
- *   to the test cases.</li>
+ *       comparison will fail and yield warnings that includes the new computed values. This can be
+ *       useful when one wants to update the pom files after having made changes to the source code
+ *       or to the test cases.
  * </ul>
  */
 public class LenientLimit extends Limit {
   private static final boolean COMPUTE = System.getProperties().containsKey("computeJacoco");
-  private static final BigDecimal OFFSET = new BigDecimal(System.getProperty("offsetJacoco", "0.02"));
-  private static final BigDecimal ONE = new BigDecimal("1.00"); // .00 to keep the same scale as jacoco
-  private static final BigDecimal ZERO = new BigDecimal("0.00"); // .00 to keep the same scale as jacoco
+  private static final BigDecimal OFFSET =
+      new BigDecimal(System.getProperty("offsetJacoco", "0.02"));
+  private static final BigDecimal ONE =
+      new BigDecimal("1.00"); // .00 to keep the same scale as jacoco
+  private static final BigDecimal ZERO =
+      new BigDecimal("0.00"); // .00 to keep the same scale as jacoco
 
   @Override
   public void setMinimum(String minimum) {
     if (minimum != null) {
-      minimum = (LenientLimit.COMPUTE ? LenientLimit.ONE : new BigDecimal(minimum).subtract(LenientLimit.OFFSET)).toPlainString();
+      minimum =
+          (LenientLimit.COMPUTE
+                  ? LenientLimit.ONE
+                  : new BigDecimal(minimum).subtract(LenientLimit.OFFSET))
+              .toPlainString();
     }
     super.setMinimum(minimum);
   }
@@ -48,7 +56,11 @@ public class LenientLimit extends Limit {
   @Override
   public void setMaximum(String maximum) {
     if (maximum != null) {
-      maximum = (LenientLimit.COMPUTE ? LenientLimit.ZERO : new BigDecimal(maximum).add(LenientLimit.OFFSET)).toPlainString();
+      maximum =
+          (LenientLimit.COMPUTE
+                  ? LenientLimit.ZERO
+                  : new BigDecimal(maximum).add(LenientLimit.OFFSET))
+              .toPlainString();
     }
     super.setMaximum(maximum);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -1,210 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-/**
- * Copyright (c) Codice Foundation
- *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
- * <http://www.gnu.org/licenses/lgpl.html>.
- *
- **/
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>ddf.support</groupId>
+        <artifactId>support-pom</artifactId>
+        <version>2.3.16-SNAPSHOT</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.codice.maven</groupId>
-    <artifactId>codice-maven</artifactId>
-    <version>0.1</version>
-    <packaging>pom</packaging>
-    <name>Codice Maven</name>
-    <description>Codice Maven Generic Utilities, Classes, and Plugins</description>
-
-    <inceptionYear>2018</inceptionYear>
-    <organization>
-        <name>Codice Foundation</name>
-        <url>http://codice.org</url>
-    </organization>
-    <licenses>
-        <license>
-            <name>GNU Lesser General Public v3</name>
-            <url>http://www.gnu.org/licenses/lgpl.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <properties>
-        <!--  default URL properties -->
-        <codice.scm.connection.url />
-        <snapshots.repository.url />
-        <reports.repository.url />
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-
-        <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
-
-        <jsr305.version>3.0.2_1</jsr305.version>
-
-        <junit.version>4.12</junit.version>
-    </properties>
-
-    <scm>
-        <url>https://github.com/codice/codice-maven</url>
-        <connection>scm:git:https://github.com/codice/codice-maven.git</connection>
-        <developerConnection>scm:git:https://github.com/codice/codice-maven.git</developerConnection>
-        <tag>codice-maven-0.1</tag>
-    </scm>
-
-    <distributionManagement>
-        <!--
-	    NOTE: The properties snapshots.repository.url and releases.repository.url should be defined in your .m2/settings.xml file.
-	-->
-        <snapshotRepository>
-            <id>snapshots</id>
-            <url>${snapshots.repository.url}</url>
-        </snapshotRepository>
-        <repository>
-            <id>releases</id>
-            <url>${releases.repository.url}</url>
-        </repository>
-        <site>
-            <id>reports</id>
-            <url>${reports.repository.url}</url>
-        </site>
-    </distributionManagement>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.servicemix.bundles</groupId>
-                <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
-                <version>${jsr305.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-		<scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+    <artifactId>support-jacoco</artifactId>
+    <name>DDF Support Jacoco</name>
+    
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${maven-jacoco-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>default-prepare-agent</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
-                    <configuration>
-                        <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
-                        <includes>
-                            <include>**/*Test.java</include>
-                            <include>**/*Spec.class</include>
-                        </includes>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-
         <plugins>
             <plugin>
-                <groupId>com.coveo</groupId>
-                <artifactId>fmt-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.codehaus.gmaven</groupId>
+                <artifactId>gmaven-plugin</artifactId>
+                <version>1.4</version>
+                <configuration>
+                    <source>
+                        src/main/groovy/updatePomFiles.groovy
+                    </source>
+                </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <haltOnFailure>true</haltOnFailure>
-                            <rules>
-                                <rule>
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>INSTRUCTION</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>BRANCH</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>COMPLEXITY</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>
 
-    <profiles>
-    </profiles>
-
-    <modules>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.codehaus.gmaven.runtime</groupId>
+            <artifactId>gmaven-runtime-1.7</artifactId>
+            <version>1.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>1.7.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+            <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${maven.jacoco.plugin.version}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,65 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>ddf.support</groupId>
-        <artifactId>support-pom</artifactId>
-        <version>2.3.16-SNAPSHOT</version>
-    </parent>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>support-jacoco</artifactId>
-    <name>DDF Support Jacoco</name>
-    
+    <groupId>org.codice.maven</groupId>
+    <artifactId>codice-maven</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Codice Maven</name>
+    <description>Codice Maven Generic Utilities, Classes, and Plugins</description>
+
+    <inceptionYear>2018</inceptionYear>
+    <organization>
+        <name>Codice Foundation</name>
+        <url>http://codice.org</url>
+    </organization>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public v3</name>
+            <url>http://www.gnu.org/licenses/lgpl.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <!--  default URL properties -->
+        <codice.scm.connection.url/>
+        <snapshots.repository.url/>
+        <reports.repository.url/>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
+
+        <jsr305.version>3.0.2_1</jsr305.version>
+
+        <junit.version>4.12</junit.version>
+    </properties>
+
+    <scm>
+        <url>https://github.com/codice/codice-maven</url>
+        <connection>scm:git:https://github.com/codice/codice-maven.git</connection>
+        <developerConnection>scm:git:https://github.com/codice/codice-maven.git
+        </developerConnection>
+        <tag>codice-maven-0.1</tag>
+    </scm>
+
+    <distributionManagement>
+        <!--
+	    NOTE: The properties snapshots.repository.url and releases.repository.url should be defined in your .m2/settings.xml file.
+	-->
+        <snapshotRepository>
+            <id>snapshots</id>
+            <url>${snapshots.repository.url}</url>
+        </snapshotRepository>
+        <repository>
+            <id>releases</id>
+            <url>${releases.repository.url}</url>
+        </repository>
+        <site>
+            <id>reports</id>
+            <url>${reports.repository.url}</url>
+        </site>
+    </distributionManagement>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.servicemix.bundles</groupId>
+                <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
+                <version>${jsr305.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.2.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${maven-jacoco-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codice.maven</groupId>
+                            <artifactId>jacoco</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.20.1</version>
+                    <configuration>
+                        <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
+                        <includes>
+                            <include>**/*Test.java</include>
+                            <include>**/*Spec.class</include>
+                        </includes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <source>
-                        src/main/groovy/updatePomFiles.groovy
-                    </source>
-                </configuration>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit implementation="org.codice.jacoco.LenientLimit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.codehaus.gmaven.runtime</groupId>
-            <artifactId>gmaven-runtime-1.7</artifactId>
-            <version>1.3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>1.7.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-invoker</artifactId>
-            <version>2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${maven.jacoco.plugin.version}</version>
-        </dependency>
-    </dependencies>
+    <profiles>
+    </profiles>
+
+    <modules>
+        <module>jacoco</module>
+    </modules>
 </project>

--- a/src/main/java/org/codice/jacoco/LenientLimit.java
+++ b/src/main/java/org/codice/jacoco/LenientLimit.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.jacoco;
+
+import java.math.BigDecimal;
+import org.jacoco.report.check.Limit;
+
+/**
+ * Extension to Jacoco's {@link Limit} class which is more lenient with respect to the minimum and
+ * maximum limits to which a value is compared against. This should help account for small differences
+ * in Java compiler and OS as these can be generating different bytecodes.
+ *
+ * <p>System properties supported:
+ * <ul>
+ *   <li>offsetJacoco - specifies the offset to apply to the minum and maximum values read from pom
+ *   files in order to be lenient about the comparison. Defaults to 0.02.</li>
+ *   <li>computeJacoco - forces the limit minimum and maximum values as such that Jacoco's
+ *   comparison will fail and yield warnings that includes the new computed values. This can be
+ *   useful when one wants to update the pom files after having made changes to the source code or
+ *   to the test cases.</li>
+ * </ul>
+ */
+public class LenientLimit extends Limit {
+  private static final boolean COMPUTE = System.getProperties().containsKey("computeJacoco");
+  private static final BigDecimal OFFSET = new BigDecimal(System.getProperty("offsetJacoco", "0.02"));
+
+  @Override
+  public void setMinimum(String minimum) {
+    if (minimum != null) {
+      minimum = (LenientLimit.COMPUTE ? BigDecimal.ONE : new BigDecimal(minimum).subtract(LenientLimit.OFFSET)).toPlainString();
+    }
+    super.setMinimum(minimum);
+  }
+
+  @Override
+  public void setMaximum(String maximum) {
+    if (maximum != null) {
+      maximum = (LenientLimit.COMPUTE ? BigDecimal.ZERO : new BigDecimal(maximum).add(LenientLimit.OFFSET)).toPlainString();
+    }
+    super.setMaximum(maximum);
+  }
+}

--- a/src/main/java/org/codice/jacoco/LenientLimit.java
+++ b/src/main/java/org/codice/jacoco/LenientLimit.java
@@ -23,7 +23,7 @@ import org.jacoco.report.check.Limit;
  *
  * <p>System properties supported:
  * <ul>
- *   <li>offsetJacoco - specifies the offset to apply to the minum and maximum values read from pom
+ *   <li>offsetJacoco - specifies the offset to apply to the minimum and maximum values read from pom
  *   files in order to be lenient about the comparison. Defaults to 0.02.</li>
  *   <li>computeJacoco - forces the limit minimum and maximum values as such that Jacoco's
  *   comparison will fail and yield warnings that includes the new computed values. This can be
@@ -34,11 +34,13 @@ import org.jacoco.report.check.Limit;
 public class LenientLimit extends Limit {
   private static final boolean COMPUTE = System.getProperties().containsKey("computeJacoco");
   private static final BigDecimal OFFSET = new BigDecimal(System.getProperty("offsetJacoco", "0.02"));
+  private static final BigDecimal ONE = new BigDecimal("1.00"); // .00 to keep the same scale as jacoco
+  private static final BigDecimal ZERO = new BigDecimal("0.00"); // .00 to keep the same scale as jacoco
 
   @Override
   public void setMinimum(String minimum) {
     if (minimum != null) {
-      minimum = (LenientLimit.COMPUTE ? BigDecimal.ONE : new BigDecimal(minimum).subtract(LenientLimit.OFFSET)).toPlainString();
+      minimum = (LenientLimit.COMPUTE ? LenientLimit.ONE : new BigDecimal(minimum).subtract(LenientLimit.OFFSET)).toPlainString();
     }
     super.setMinimum(minimum);
   }
@@ -46,7 +48,7 @@ public class LenientLimit extends Limit {
   @Override
   public void setMaximum(String maximum) {
     if (maximum != null) {
-      maximum = (LenientLimit.COMPUTE ? BigDecimal.ZERO : new BigDecimal(maximum).add(LenientLimit.OFFSET)).toPlainString();
+      maximum = (LenientLimit.COMPUTE ? LenientLimit.ZERO : new BigDecimal(maximum).add(LenientLimit.OFFSET)).toPlainString();
     }
     super.setMaximum(maximum);
   }


### PR DESCRIPTION
**DO NOT SQUASH SUCH AS TO PRESERVE HISTORY FROM ORIGINAL DDF-SUPPORT REPOSITORY**

### Description of the Change
This relocates the jacoco lenient limit artifact from ddf-support.

### Benefits
It makes these artifacts reusable in other repositories.

### Verification Process
- builds from the command line

### Applicable Issues
Fixes: #1 