### PR TITLE
MAVEN-6 Upgraded Jacoco to 0.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <!-- Maven Plugin Version Properties -->
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
         <dependency-check-maven.version>3.1.1</dependency-check-maven.version>
-        <maven-jacoco-plugin.version>0.8.1</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.8.2</maven-jacoco-plugin.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
### Description of the Change
Upgraded to Jacoco 0.8.2.

### Benefits
Jacoco 0.8.2 supports Java 11

### Possible Drawbacks
None. It is still backward compatible.

### Verification Process
Successful build

### Applicable Issues
Fixes: #6 