### PR TITLE
BR-5 Update Codice-Maven to run on changes, instead of nightly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
           Restrict nightly builds to master branch, all others will be built on change only.
           Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
         */
-        pollSCM(BRANCH_NAME == "master" ? "H H(7-9) * * *" : "")
+        pollSCM(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
     }
     environment {
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
           Restrict nightly builds to master branch, all others will be built on change only.
           Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
         */
-        cron(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")
+        pollSCM(BRANCH_NAME == "master" ? "H H(7-9) * * *" : "")
     }
     environment {
         DISABLE_DOWNLOAD_PROGRESS_OPTS = '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn '

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     }
     triggers {
         /*
-          Restrict nightly builds to master branch, all others will be built on change only.
+          Restrict nightly builds to master branch only if changed, all others will be built on change only.
           Note: The BRANCH_NAME will only work with a multi-branch job using the github-branch-source
         */
         pollSCM(BRANCH_NAME == "master" ? "H H(17-19) * * *" : "")


### PR DESCRIPTION
#### What does this PR do, and why?
Changes  the nightly build of master branch to only occur on change to code after polling

#### How should this be tested?
. Run the codice-maven job in Jenkins
. Navigate to the master branch >View Configuration 
. Under Build Triggers, see that Build Periodically is unchecked
. Under Build Triggers, see that Poll SCM is checked
. Poll SCM should have the cron type schedule "H H(17-19) * * *" 
  
#### PR Definition of Done

- minimum 2 reviewer approval (specify reviewers on the right)

- All comments resolved (nit comments are the exception and left up to the author)


Any exceptions to the above should be justified prior to merging

#### Relevant links:

[BR-5](https://connexta.atlassian.net/jira/software/projects/BR/boards/47?selectedIssue=BR-5)

#### Screenshots: (if appropriate)
![image](https://user-images.githubusercontent.com/53581477/64281555-3e18a000-cf08-11e9-92e3-80d6863eb603.png)

#### Checklist:
no change to actual codebase other than Jenkinsfile to control frequency of building master branch